### PR TITLE
Default BOOTSTATE to "USER" in init script

### DIFF
--- a/debian/dsme.upstart
+++ b/debian/dsme.upstart
@@ -7,7 +7,12 @@ stop on starting shutdown
 console output
 
 script
-        export BOOTSTATE=`cat /var/lib/dsme/saved_state`
+        if [ -f "/var/lib/dsme/saved_state" ]
+        then
+            export BOOTSTATE=`cat /var/lib/dsme/saved_state`
+        else
+            export BOOTSTATE="USER"
+        fi
         touch /tmp/$BOOTSTATE
         echo $BOOTSTATE > /tmp/STATE
 


### PR DESCRIPTION
If /var/lib/dsme/saved_state does not exist, set BOOTSTATE to "USER" to avoid DSME rebooting system.